### PR TITLE
Bug Fix to include subCollections when linking Published elements.

### DIFF
--- a/woody/panels.py
+++ b/woody/panels.py
@@ -100,9 +100,15 @@ def is_collection_linked_and_not_overridden(col):
 def is_collection_override_of_published(col):
     if not col.override_library:
         return False
+
+    # Make sure it's directly in the scene
+    if col.name not in [c.name for c in bpy.context.scene.collection.children]:
+        return False
+
     ref = col.override_library.reference
     if not ref or not ref.library:
         return False
+
     return "_published.blend" in ref.library.filepath
 
 def is_published_file_already_in_scene(blend_path):


### PR DESCRIPTION
Updated logic when creating published file to include sub collections and contents, also had to modify the naming of published files to include 'type'. When linking a published it will search for the collection with name 'root_group_asset_type' to make sure we grab the parent collection (the sub collection will follow with). When overwriting had to make sure we only display the parent collection in the panel display.