### PR TITLE
Mp4 rendering logic + changed render logic

### DIFF
--- a/woody/utils.py
+++ b/woody/utils.py
@@ -176,7 +176,7 @@ def apply_render_config(config_path: str):
     render.use_persistent_data = settings.get("use_persistent_data", render.use_persistent_data)
     
 
-    print(f"✅ Render settings applied from {config_path}")
+    print(f"[apply_render_config]✅ Render settings applied from {config_path}")
 
 def generate_config_script(config_path):
     # Create a temp script that runs inside Blender
@@ -190,7 +190,7 @@ with open(r"{config_path}", "r") as f:
 
 bpy.context.scene.frame_start = config.get("frame_start", 1)
 bpy.context.scene.frame_end = config.get("frame_end", 250)
-print(f"✅ Frame range set from config: {{bpy.context.scene.frame_start}} to {{bpy.context.scene.frame_end}}")
+print(f"[generate_config_script] ✅ Frame range set from config: {{bpy.context.scene.frame_start}} to {{bpy.context.scene.frame_end}}")
 """)
     script.close()
     return script.name


### PR DESCRIPTION
Modified the render logic to run a subprocess and render the frames there, which allows the user to interact with the scene while it is rendering.

Also added a toggle when rendering to "make mp4" which will run a second subprocess and render out an mp4.

Mp4s are stored in a folder called _mp4 located in cg, with a timestamp and frames folder version.

Potential issues:

Cancelling the render is not yet fully implemented.

