### PR TITLE
Blender Addon Template

### DIFF
--- a/woody/dcc/blender/blender.py
+++ b/woody/dcc/blender/blender.py
@@ -44,6 +44,7 @@ class Blender():
         
     def launch(self):
         if self.exe:
-            subprocess.run([str(self.exe)])
+            startup_script = Path(__file__).parent / "startup.py"
+            subprocess.run([str(self.exe), "--python", str(startup_script)])
         else:
             raise WoodyError("Blender executable not set. Run install first.", "error")

--- a/woody/dcc/blender/startup.py
+++ b/woody/dcc/blender/startup.py
@@ -1,0 +1,26 @@
+"""
+Woody Blender Startup Script
+This script is executed when Blender launches with Woody integration
+Registers the Woody addon and initializes the Woody environment.
+"""
+
+import sys
+from pathlib import Path
+from woody.pywoody import Woody
+
+# Get the addon directory
+addon_dir = Path(__file__).parent
+
+# Add to sys.path if not already there
+addon_dir_str = str(addon_dir)
+if addon_dir_str not in sys.path:
+    sys.path.insert(0, addon_dir_str)
+
+# Import and register the Woody addon
+try:
+    import woody_addon
+    woody_addon.register()
+    Woody().run()
+    print("Woody addon registered successfully!")
+except Exception as e:
+    print(f"Failed to register Woody addon: {e}")

--- a/woody/dcc/blender/woody_addon.py
+++ b/woody/dcc/blender/woody_addon.py
@@ -1,0 +1,56 @@
+import bpy
+from woody.pywoody.handlers.processor import Processor
+
+bl_info = {
+    "name": "Woody",
+    "author": "Woody Team",
+    "version": (1, 0, 0),
+    "blender": (5, 0, 1),
+    "location": "View3D > Sidebar > Woody",
+    "description": "Woody Pipeline Integration",
+    "category": "Pipeline",
+}
+
+class WOODY_PT_MainPanel(bpy.types.Panel):
+    """Woody Main Panel"""
+    bl_label = "Woody"
+    bl_idname = "WOODY_PT_main_panel"
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'Woody'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.operator("woody.test_button")
+
+
+class WOODY_OT_TestButton(bpy.types.Operator):
+    """temp operator"""
+    bl_label = "Print Hello"
+    bl_idname = "woody.test_button"
+
+    def execute(self, context):
+        print("Hello")
+        Processor().list_projects()
+        self.report({'INFO'}, "Hello")
+        return {'FINISHED'}
+
+
+classes = (
+    WOODY_PT_MainPanel,
+    WOODY_OT_TestButton,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+
+
+if __name__ == "__main__":
+    register()


### PR DESCRIPTION
This pull request adds initial support for integrating the Woody pipeline with Blender by introducing a Blender addon and updating the launch process to ensure the addon is registered and initialized on startup. The main changes focus on enabling Woody features within Blender's UI and ensuring proper initialization when Blender is launched via the Woody tool.

**Blender Addon Integration:**

* Added a new Blender addon in `woody_addon.py` that registers a sidebar panel and a test operator in Blender's UI, enabling basic Woody pipeline interaction. The addon uses the Woody processor to list projects as a demonstration.

**Startup and Launch Improvements:**

* Introduced a new `startup.py` script that is executed when Blender launches, ensuring the Woody addon is registered and the Woody environment is initialized. The script handles sys.path setup and error reporting.
* Updated the `launch` method in `blender.py` to start Blender with the `startup.py` script, ensuring the addon is registered on launch.